### PR TITLE
Fix path to WebIdeXX for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ OS | Location
 Windows XP | `C:\Documents and Settings\<User name>\.WebIdeXX\config`
 Windows Vista | `C:\Users\<User name>\.WebIdeXX\config`
 Linux | `~/.WebIdeXX/config`
-Mac OS | `~/Library/Preferences/.WebIdeXX`
+Mac OS | `~/Library/Preferences/WebIdeXX`
 
 See [Project and IDE settings](http://www.jetbrains.com/phpstorm/webhelp/project-and-ide-settings.html#d610183e276) for more information.
 


### PR DESCRIPTION
Today the `WebIDEXX` folder doesn't start with a dot on osx

Maybe prior to PhpStorm 8 the folder was hidden tho.
